### PR TITLE
fix(): teardown with Flux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,15 +31,22 @@ tf-destroy:
 	@terraform -chdir=terraform/production/eu-west9/ apply
 	@terraform -chdir=terraform/production/us-east1/ apply
 
-## Destroy only the terraform resources that costs $$$
+## Destroy Flux resources and the GKE clusters
 tf-teardown:
+	export KUBECONFIG=~/.kube/foobar-eu
+	@kubectl -n flux-system delete gitrepository --all
+	@kubectl -n flux-system delete kustomization --all
 	@terraform -chdir=terraform/production/eu-west9/ destroy -target=module.gke
+	export KUBECONFIG=~/.kube/foobar-us
+	@kubectl -n flux-system delete gitrepository --all
+	@kubectl -n flux-system delete kustomization --all
 	@terraform -chdir=terraform/production/us-east1/ destroy -target=module.gke
 
 ## Get the Kubernetes contexts and put them in ~/.kube/foobar
 kube-init:
-	export KUBECONFIG=~/.kube/foobar
+	export KUBECONFIG=~/.kube/foobar-eu
 	@gcloud container clusters get-credentials foobar-europe-west9 --region=europe-west9 --project $(project)
+	export KUBECONFIG=~/.kube/foobar-us
 	@gcloud container clusters get-credentials foobar-us-east1 --region=us-east1 --project $(project)
 
 ## Print this help message

--- a/README.md
+++ b/README.md
@@ -23,4 +23,5 @@ Targets:
 ## Read More
 
 If you want to dive into the code and start playing with the repository, check the [setup documentation](./docs/setup.md) and start playing around!
+
 If you're interested about the architecture, the reasoning and the choices made here, check the [challenge documentation](./docs/challenge.md)


### PR DESCRIPTION
Sadly terraform isn't handling the dependency tree properly. It tries to delete the `flux-system` namespace before removing flux itself.

This eventually fails because of Kubernetes finalizers set on the namespace. 
Two solutions have been implemented:
1. Update the Makefile to remove Flux resources before destroying with terraform
2. Add proper dependencies between terraform Flux resources