### PR TITLE
feat(): use the main docker image

### DIFF
--- a/kubernetes/base/foobar/foobar-api/deployment.yml
+++ b/kubernetes/base/foobar/foobar-api/deployment.yml
@@ -50,7 +50,7 @@ spec:
 
       containers:
         - name: foobar-api
-          image: ghcr.io/barolab/foobar-api:feat-foobar-api-release
+          image: ghcr.io/barolab/foobar-api:main
           ports:
             - name: https
               protocol: TCP


### PR DESCRIPTION
A new Docker image for `foobar-api` has been released, we should be using this one on GKE