### PR TITLE
fix(): wrongly name docker config secrets

### DIFF
--- a/terraform/production/eu-west9/main.tf
+++ b/terraform/production/eu-west9/main.tf
@@ -115,7 +115,7 @@ resource "kubernetes_secret" "ghcr" {
   depends_on = [kubernetes_namespace.namespace]
 
   metadata {
-    name      = "gchr"
+    name      = "ghcr"
     namespace = each.key
   }
 


### PR DESCRIPTION
The secret with the Docker config for access ghcr.io has a typo.