### PR TITLE
fix(): flux kustomize variables

### DIFF
--- a/kubernetes/production/eu-west9/flux-system/kube-security.yml
+++ b/kubernetes/production/eu-west9/flux-system/kube-security.yml
@@ -22,4 +22,3 @@ spec:
     substituteFrom:
       - kind: ConfigMap
         name: cluster-variables
-        namespace: kube-security

--- a/kubernetes/production/us-east1/flux-system/kube-security.yml
+++ b/kubernetes/production/us-east1/flux-system/kube-security.yml
@@ -22,4 +22,3 @@ spec:
     substituteFrom:
       - kind: ConfigMap
         name: cluster-variables
-        namespace: kube-security

--- a/terraform/production/dns/outputs.tf
+++ b/terraform/production/dns/outputs.tf
@@ -1,0 +1,9 @@
+output "eu_lb" {
+  description = "Details about the EU Load Balancer"
+  value = data.kubernetes_service.traefik_proxy_eu
+}
+
+output "us_lb" {
+  description = "Details about the US Load Balancer"
+  value = data.kubernetes_service.traefik_proxy_us
+}

--- a/terraform/production/eu-west9/main.tf
+++ b/terraform/production/eu-west9/main.tf
@@ -163,7 +163,7 @@ resource "kubernetes_config_map" "variables" {
 
   data = {
     gcp_project = var.project
-    gcp_region  = var.region
+    gcp_region  = local.region
 
     cert_manager_fqdn  = module.cert_manager.gcp_service_account_fqn
     cert_manager_email = module.cert_manager.gcp_service_account_email

--- a/terraform/production/us-east1/main.tf
+++ b/terraform/production/us-east1/main.tf
@@ -162,7 +162,7 @@ resource "kubernetes_config_map" "variables" {
 
   data = {
     gcp_project = var.project
-    gcp_region  = var.region
+    gcp_region  = local.region
 
     cert_manager_fqdn  = module.cert_manager.gcp_service_account_fqn
     cert_manager_email = module.cert_manager.gcp_service_account_email


### PR DESCRIPTION
Two bugs on the Flux Kustomize variable substition:
1. Wrong terraform reference for the cluster region
2. Wrong and unsupported namespace for Kustomization CM reference