### PR TITLE
feat(): observability on all services

### DIFF
--- a/kubernetes/base/kube-network/kustomization.yaml
+++ b/kubernetes/base/kube-network/kustomization.yaml
@@ -4,6 +4,7 @@ namespace: flux-system
 resources:
   - traefik-proxy/deployment.yaml
   - traefik-proxy/ingress-class.yaml
+  - traefik-proxy/monitor.yaml
   - traefik-proxy/pdb.yaml
   - traefik-proxy/rbac.yaml
   - traefik-proxy/service-api.yaml

--- a/kubernetes/base/kube-network/traefik-proxy/monitor.yaml
+++ b/kubernetes/base/kube-network/traefik-proxy/monitor.yaml
@@ -1,0 +1,25 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: traefik-propxy
+  namespace: kube-network
+  labels:
+    app.kubernetes.io/name: traefik-proxy
+    app.kubernetes.io/instance: traefik-proxy
+    app.kubernetes.io/component: network
+    app.kubernetes.io/part-of: traefik
+    app.kubernetes.io/managed-by: flux
+    app.kubernetes.io/agent: grafana
+spec:
+  namespaceSelector:
+    matchNames:
+      - kube-network
+
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: traefik-proxy
+      app.kubernetes.io/instance: traefik-proxy-api
+
+  endpoints:
+    - path: /metrics
+      port: metrics

--- a/kubernetes/base/kube-network/traefik-proxy/service-api.yaml
+++ b/kubernetes/base/kube-network/traefik-proxy/service-api.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: v1
 kind: Service
 metadata:
@@ -6,7 +5,7 @@ metadata:
   namespace: kube-network
   labels:
     app.kubernetes.io/name: traefik-proxy
-    app.kubernetes.io/instance: traefik-proxy
+    app.kubernetes.io/instance: traefik-proxy-api
     app.kubernetes.io/component: network
     app.kubernetes.io/part-of: traefik
     app.kubernetes.io/managed-by: flux

--- a/kubernetes/base/kube-network/traefik-proxy/service-lb.yaml
+++ b/kubernetes/base/kube-network/traefik-proxy/service-lb.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-network
   labels:
     app.kubernetes.io/name: traefik-proxy
-    app.kubernetes.io/instance: traefik-proxy
+    app.kubernetes.io/instance: traefik-proxy-lb
     app.kubernetes.io/component: network
     app.kubernetes.io/part-of: traefik
     app.kubernetes.io/managed-by: flux

--- a/kubernetes/base/kube-observability/grafana-operator/deployment.yaml
+++ b/kubernetes/base/kube-observability/grafana-operator/deployment.yaml
@@ -35,7 +35,7 @@ spec:
             - --kubelet-service=default/kubelet
 
           ports:
-            - name: http-metrics
+            - name: metrics
               protocol: TCP
               containerPort: 8080
 

--- a/kubernetes/base/kube-observability/grafana-operator/monitor.yaml
+++ b/kubernetes/base/kube-observability/grafana-operator/monitor.yaml
@@ -1,0 +1,25 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: grafana-agent-operator
+  namespace: kube-observability
+  labels:
+    app.kubernetes.io/name: grafana-agent
+    app.kubernetes.io/instance: grafana-agent-operator
+    app.kubernetes.io/component: observability
+    app.kubernetes.io/part-of: grafana
+    app.kubernetes.io/managed-by: flux
+    app.kubernetes.io/agent: grafana
+spec:
+  namespaceSelector:
+    matchNames:
+      - kube-network
+
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: grafana-agent
+      app.kubernetes.io/instance: grafana-agent-operator
+
+  endpoints:
+    - path: /metrics
+      port: metrics

--- a/kubernetes/base/kube-observability/grafana-operator/service.yaml
+++ b/kubernetes/base/kube-observability/grafana-operator/service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: grafana-agent-operator
+  namespace: kube-observability
+  labels:
+    app.kubernetes.io/name: grafana-agent
+    app.kubernetes.io/instance: grafana-agent-operator
+    app.kubernetes.io/component: observability
+    app.kubernetes.io/part-of: grafana
+    app.kubernetes.io/managed-by: flux
+spec:
+  type: ClusterIP
+  ports:
+    - name: metrics
+      port: 8080
+      protocol: TCP
+      targetPort: 8080
+  selector:
+    app.kubernetes.io/name: grafana-agent
+    app.kubernetes.io/instance: grafana-agent-operator

--- a/kubernetes/base/kube-observability/kustomization.yaml
+++ b/kubernetes/base/kube-observability/kustomization.yaml
@@ -4,7 +4,9 @@ namespace: flux-system
 resources:
   # Grafana Operator
   - grafana-operator/deployment.yaml
+  - grafana-operator/monitor.yaml
   - grafana-operator/rbac.yaml
+  - grafana-operator/service.yaml
 
   # Grafana Agent
   - grafana-agent/agent.yaml

--- a/kubernetes/base/kube-security/cert-manager/helm-release.yaml
+++ b/kubernetes/base/kube-security/cert-manager/helm-release.yaml
@@ -92,4 +92,8 @@ spec:
             - ALL
 
     prometheus:
-      enabled: false
+      enabled: true
+      servicemonitor:
+        enabled: true
+        labels:
+          app.kubernetes.io/agent: grafana


### PR DESCRIPTION
Now that we have a monitoring service available, we can configure it to scrape the traefik-proxy, cert-manager, and grafana-operator services. Once we have enough metrics on Grafana Cloud we'll be able to setup some dashboards.