### PR TITLE
feat(): foobar-api HTTP base health checks

### DIFF
--- a/kubernetes/base/foobar/foobar-api/deployment.yaml
+++ b/kubernetes/base/foobar/foobar-api/deployment.yaml
@@ -65,11 +65,26 @@ spec:
               cpu: 100m
 
           readinessProbe:
-            tcpSocket:
+            initialDelaySeconds: 2
+            failureThreshold: 1
+            successThreshold: 1
+            timeoutSeconds: 2
+            periodSeconds: 10
+            httpGet:
+              path: /health
               port: 80
+              scheme: HTTPS
+
           livenessProbe:
-            tcpSocket:
+            initialDelaySeconds: 2
+            failureThreshold: 3
+            successThreshold: 1
+            timeoutSeconds: 2
+            periodSeconds: 10
+            httpGet:
+              path: /health
               port: 80
+              scheme: HTTPS
 
           volumeMounts:
             - name: cert


### PR DESCRIPTION
Change in the foobar-api health checks, since we're now checking that the HTTP server sends back a valid HTTP response instead of just checking the TCP socket.