### PR TITLE
fix(): observability base issues

### DIFF
--- a/kubernetes/base/kube-observability/grafana-agent/agent.yaml
+++ b/kubernetes/base/kube-observability/grafana-agent/agent.yaml
@@ -18,10 +18,6 @@ spec:
         app.kubernetes.io/agent: grafana
 
   logs:
-    externalLabels:
-      cluster: ${gcp_cluster}
-      project: ${gcp_project}
-      region: ${gcp_region}
     instanceSelector:
       matchLabels:
         app.kubernetes.io/agent: grafana

--- a/kubernetes/base/kube-observability/grafana-agent/instance-log.yaml
+++ b/kubernetes/base/kube-observability/grafana-agent/instance-log.yaml
@@ -11,8 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: flux
     app.kubernetes.io/agent: grafana
 type: Opaque
-data: {}
-stringData:
+data:
   password: "${grafana_loki_password}"
   username: "${grafana_loki_username}"
 ---

--- a/kubernetes/base/kube-observability/grafana-agent/instance-metrics.yaml
+++ b/kubernetes/base/kube-observability/grafana-agent/instance-metrics.yaml
@@ -11,8 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: flux
     app.kubernetes.io/agent: grafana
 type: Opaque
-data: {}
-stringData:
+data:
   password: "${grafana_prometheus_password}"
   username: "${grafana_prometheus_username}"
 ---

--- a/terraform/production/eu-west9/main.tf
+++ b/terraform/production/eu-west9/main.tf
@@ -170,11 +170,11 @@ resource "kubernetes_config_map" "variables" {
     cert_manager_email = module.cert_manager.gcp_service_account_email
 
     grafana_prometheus_url      = var.grafana_prometheus_url
-    grafana_prometheus_username = var.grafana_prometheus_username
-    grafana_prometheus_password = var.grafana_prometheus_password
+    grafana_prometheus_username = base64encode(var.grafana_prometheus_username)
+    grafana_prometheus_password = base64encode(var.grafana_prometheus_password)
     grafana_loki_url            = var.grafana_loki_url
-    grafana_loki_username       = var.grafana_loki_username
-    grafana_loki_password       = var.grafana_loki_password
+    grafana_loki_username       = base64encode(var.grafana_loki_username)
+    grafana_loki_password       = base64encode(var.grafana_loki_password)
   }
 
   lifecycle {

--- a/terraform/production/us-east1/main.tf
+++ b/terraform/production/us-east1/main.tf
@@ -169,11 +169,11 @@ resource "kubernetes_config_map" "variables" {
     cert_manager_email = module.cert_manager.gcp_service_account_email
 
     grafana_prometheus_url      = var.grafana_prometheus_url
-    grafana_prometheus_username = var.grafana_prometheus_username
-    grafana_prometheus_password = var.grafana_prometheus_password
+    grafana_prometheus_username = base64encode(var.grafana_prometheus_username)
+    grafana_prometheus_password = base64encode(var.grafana_prometheus_password)
     grafana_loki_url            = var.grafana_loki_url
-    grafana_loki_username       = var.grafana_loki_username
-    grafana_loki_password       = var.grafana_loki_password
+    grafana_loki_username       = base64encode(var.grafana_loki_username)
+    grafana_loki_password       = base64encode(var.grafana_loki_password)
   }
 
   lifecycle {


### PR DESCRIPTION
This fixes two problems:
1. The Flux Kustomize variable substition doesn't work well with numbers. The solution is to use base64 when creating the ConfigMap used by Flux, and use `data` instead of `stringData` on the `Secret`
2. Some fields don't match the schema