### PR TITLE
feat(): add mtls to foobar-api and secure Docker

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -10,12 +10,19 @@ COPY *.go ./
 RUN go build -o /foobar-api
 
 ## Deploy
-FROM alpine:3.9
+FROM alpine:3.17
 
 WORKDIR /
-RUN apk add ca-certificates=20191127-r2 --no-cache &&  \
-    rm -rf /var/cache/apk/*
 COPY --from=build /foobar-api /app
+ENV UID=65532
+ENV GID=65532
+RUN apk add ca-certificates=20220614-r4 --no-cache &&  \
+    rm -rf /var/cache/apk/* && \
+    addgroup --gid 65532 app && \
+    adduser --disabled-password --gecos "" --home / --ingroup app --no-create-home --uid 65532 app && \
+    chown app:app /app && \
+    chmod +x /app
 
+USER app
 EXPOSE 80
 ENTRYPOINT ["/app"]

--- a/app/main.go
+++ b/app/main.go
@@ -65,6 +65,11 @@ func main() {
 		Addr: ":" + port,
 	}
 
+	// If a CA is present, load it
+	if _, err := os.Stat("/cert/ca.pem"); err != nil {
+		server.TLSConfig = setupMutualTLS("/cert/ca.pem")
+	}
+
 	_, err := os.Stat("/cert/cert.pem")
 	if err != nil {
 		log.Fatal("You need to provide a certificate")


### PR DESCRIPTION
Introduce the ability to enable mTLS on the foobar-api by giving a CA certificate.
This also improve the Docker image security by setting a non-root user by default.