### PR TITLE
fix(): add missing NET_BIND_SERVICE cap to foobar-api

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -16,12 +16,13 @@ WORKDIR /
 COPY --from=build /foobar-api /app
 ENV UID=65532
 ENV GID=65532
-RUN apk add ca-certificates=20220614-r4 --no-cache &&  \
+RUN apk add libcap=2.66-r0 ca-certificates=20220614-r4 --update --no-cache &&  \
     rm -rf /var/cache/apk/* && \
     addgroup --gid 65532 app && \
     adduser --disabled-password --gecos "" --home / --ingroup app --no-create-home --uid 65532 app && \
     chown app:app /app && \
-    chmod +x /app
+    chmod +x /app && \
+    setcap CAP_NET_BIND_SERVICE=+eip /app
 
 USER app
 EXPOSE 80


### PR DESCRIPTION
This add a missing Linux Capability on the foobar-api binary, which is require to bind a listener on system port (eg. 80).