### PR TITLE
fix(): foobar name FQDN

### DIFF
--- a/kubernetes/base/foobar/foobar-api/statfulset.yaml
+++ b/kubernetes/base/foobar/foobar-api/statfulset.yaml
@@ -65,7 +65,7 @@ spec:
                   fieldPath: metadata.namespace
 
             - name: WHOAMI_NAME
-              value: "$(POD_NAME).$(POD_NAMESPACE).svc.cluster.local"
+              value: "$(POD_NAME).$(POD_NAMESPACE).pod.cluster.local"
 
           resources:
             requests:

--- a/kubernetes/base/foobar/foobar-mtls/statfulset.yaml
+++ b/kubernetes/base/foobar/foobar-mtls/statfulset.yaml
@@ -81,7 +81,7 @@ spec:
                   fieldPath: metadata.namespace
 
             - name: WHOAMI_NAME
-              value: "$(POD_NAME).$(POD_NAMESPACE).svc.cluster.local"
+              value: "$(POD_NAME).$(POD_NAMESPACE).pod.cluster.local"
 
           resources:
             requests:


### PR DESCRIPTION
this changes the environment variable WHOAMI of the foobar-api containers to match it's K8S FQDN.

There is a small typo because we used the service suffix isntead of the POD suffix.