### PR TITLE
fix(): foobar-api mTLS replicas route

### DIFF
--- a/kubernetes/base/foobar/foobar-mtls/tls.yaml
+++ b/kubernetes/base/foobar/foobar-mtls/tls.yaml
@@ -70,3 +70,5 @@ spec:
   insecureSkipVerify: false
   rootCAsSecrets:
     - foobar-mtls-server
+  certificatesSecrets:
+    - foobar-mtls-client

--- a/kubernetes/base/kube-network/routes/api.raimon.dev.yaml
+++ b/kubernetes/base/kube-network/routes/api.raimon.dev.yaml
@@ -43,6 +43,3 @@ spec:
 
   tls:
     secretName: tls-api-raimon-dev
-    options:
-      name: raimon
-      namespace: kube-security


### PR DESCRIPTION
This changes brings a fix to the `foobar-mtls` service accessibility from the public internet.

With the update to 0.1.3, the API now has the proper mTLS validation settins and expect a valid client certificate.
We're going to leverage the Traefik `ServerTransports` to automatically do that when reaching the `/mtls` path.

In the other ends this means that sending a client certificate from my laptop to Traefik is not very useful, except if I want Traefik to validate that my personnal cert has been issued by a known authority. This could make sense, but that would mean having a common issuer between regions (in the future perhaps).