### PR TITLE
fix(): lint issues in markdown doc

### DIFF
--- a/docs/challenge.md
+++ b/docs/challenge.md
@@ -643,8 +643,8 @@ While reading the application source code, you can see it asks for a name:
 ...
 
 func init() {
-	flag.StringVar(&port, "port", "80", "give me a port number")
-	flag.StringVar(&name, "name", os.Getenv("WHOAMI_NAME"), "give me a name")
+  flag.StringVar(&port, "port", "80", "give me a port number")
+  flag.StringVar(&name, "name", os.Getenv("WHOAMI_NAME"), "give me a name")
 }
 ```
 
@@ -705,7 +705,7 @@ I implemented n°1 using the following manifests:
 
 And we can see curl works !
 
-```
+```sh
 $ curl https://api.raimon.dev/mtls
 Name: foobar-mtls-0.foobar.svc.cluster.local
 Hostname: foobar-mtls-0


### PR DESCRIPTION
Fixes the following lint errors:
```sh
/github/workspace/docs/challenge.md:646:1 MD010/no-hard-tabs Hard tabs [Column: 1]
/github/workspace/docs/challenge.md:647:1 MD010/no-hard-tabs Hard tabs [Column: 1]
/github/workspace/docs/challenge.md:708 MD040/fenced-code-language Fenced code blocks should have a language specified [Context: "```"]
```